### PR TITLE
Add multithreading

### DIFF
--- a/deepsig/deepsig.py
+++ b/deepsig/deepsig.py
@@ -47,6 +47,7 @@ def main():
   parser.add_argument("-m", "--outfmt",
                       help = "The output format: json or gff3 (default)",
                       choices=['json', 'gff3'], required = False, default = "gff3")
+  parser.add_argument('-t', '--threads', action='store', type=int, default=mp.cpu_count(), help='Number of threads to use (default = number of available CPUs)')
 
   ns = parser.parse_args()
   protein_jsons = []
@@ -59,7 +60,7 @@ def main():
     Y, Ytm, Ync, cls, Ytm_norm, Ync_norm = detectsp(X, ns.organism)
     printDate("Detected %d signal peptides" % cls.count(2))
     printDate("Predicting cleavage sites")
-    cleavage = predictsp(X, cls, ns.organism, we, cpu=1)
+    cleavage = predictsp(X, cls, ns.organism, we, cpu=ns.threads)
     printDate("Writing results to output file")
     ofs = open(ns.outf, 'w')
     for i in range(len(accs)):

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(setup_dir, 'README.pypi.md'), encoding='utf-8') as f:
 
 setup(
     name='deepsig-biocomp',
-    version='0.9',
+    version='1.1',
     description='DeepSig - Predictor of signal peptides in proteins based on deep learning',
     keywords=['bioinformatics', 'annotation', 'bacteria', 'signal peptides'],
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 
 from os import path
 from setuptools import setup, find_packages
-#import deepsig
+import deepsig
 
 
 # Get the long description from the README file
@@ -12,7 +12,7 @@ with open(path.join(setup_dir, 'README.pypi.md'), encoding='utf-8') as f:
 
 setup(
     name='deepsig-biocomp',
-    version='1.1',
+    version=deepsig.__version__,
     description='DeepSig - Predictor of signal peptides in proteins based on deep learning',
     keywords=['bioinformatics', 'annotation', 'bacteria', 'signal peptides'],
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     author_email='savojard@biocomp.unibo.it',
     url='https://github.com/BolognaBiocomp/deepsig',
     packages=find_packages(include=['deepsig']),
-    python_requires='>=3.8',
+    python_requires='==3.8',
     include_package_data=True,
     zip_safe=False,
     install_requires=[


### PR DESCRIPTION
I've added a `--threads` parameter that is used to surpass the number of CPUs to the execution of `biocrf-static`.

Also I've bumped the version to `1.1` to express the API change.

Due to some TensorfFow dependency conflicts, DeepSig is only executable on Python 3 until `v3.8` - `v3.9` gives an error. Because of another issue I've therefore pinpointed Python to `v3.8`.